### PR TITLE
Changes in JSON/template output and fixes in parsing

### DIFF
--- a/src/libmysql/mysql.h
+++ b/src/libmysql/mysql.h
@@ -99,7 +99,7 @@ class wpl_value_MYSQL : public wpl_value {
 		return true;
 	}
 
-	string toString() override {
+	string toString() const override {
 		return string(wpl_typename_MYSQL);
 	};
 };

--- a/src/libmysql/mysql_row.h
+++ b/src/libmysql/mysql_row.h
@@ -116,7 +116,7 @@ class wpl_value_MYSQL_ROW : public wpl_value {
 		return true;
 	}
 
-	string toString() override {
+	string toString() const override {
 		return string(wpl_typename_MYSQL_ROW);
 	};
 };

--- a/src/libmysql/mysql_stmt.h
+++ b/src/libmysql/mysql_stmt.h
@@ -126,7 +126,7 @@ class wpl_value_MYSQL_STMT : public wpl_value {
 		}
 	}
 
-	string toString() override {
+	string toString() const override {
 		return string(wpl_typename_MYSQL_STMT);
 	}
 };

--- a/src/libwpl/array.cpp
+++ b/src/libwpl/array.cpp
@@ -72,6 +72,16 @@ wpl_array::~wpl_array() {
 	clear();
 }
 
+const wpl_value *wpl_array::get_readonly(int index) const {
+	if (index < 0) {
+		throw runtime_error("Attempted to read from array with negative index");
+	}
+	else if (index >= array.size()) {
+		throw runtime_error("Attempted to read from outside the array in read only mode");
+	}
+	return array[index];
+}
+
 wpl_value *wpl_array::get(int index) {
 	if (index < 0) {
 		throw runtime_error("Attempted to read from array with negative index");

--- a/src/libwpl/array.h
+++ b/src/libwpl/array.h
@@ -52,20 +52,21 @@ class wpl_array {
 
 	public:
 	void clear();
+	int size() const {
+		return array.size();
+	}
+	const wpl_value *get_readonly(int index) const;
 
 	protected:
 	wpl_array () {};
 	wpl_array (const wpl_array &copy);
-	wpl_value *get(int index);
 	void pop();
 	void set(int index, wpl_value *value);
+	wpl_value *get(int index);
 	void push(wpl_value *value);
 	void replace (wpl_array &new_array);
 	void output_json(wpl_io &io);
 	~wpl_array();
-	int size() {
-		return array.size();
-	}
 	void reserve(int i) {
 		array.reserve(i);
 	}

--- a/src/libwpl/block_conditional.cpp
+++ b/src/libwpl/block_conditional.cpp
@@ -27,6 +27,7 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "block_conditional.h"
+#include "parser.h"
 #include "value_bool.h"
 
 bool wpl_block_conditional::check_run(wpl_block_conditional_state *block_state) {
@@ -48,10 +49,10 @@ void wpl_block_conditional::find_and_parse_complete_type() {
 
 		/* Don't check for incomplete types like struct */
 		if (wpl_parseable_identifier *parseable = find_complete_type(buf)) {
-			parse_parseable_identifier(this, parseable);
+			wpl_parser::parse_parseable_identifier(this, this, parseable);
 		}
 		else if (wpl_parseable_identifier *parseable = find_template_type(buf)) {
-			parse_parseable_identifier(this, parseable);
+			wpl_parser::parse_parseable_identifier(this, this, parseable);
 		}
 		else {
 			revert_string(len);

--- a/src/libwpl/block_parser.cpp
+++ b/src/libwpl/block_parser.cpp
@@ -63,21 +63,3 @@ void wpl_block_parser::parse_parse_and_run(wpl_parse_and_run *block) {
 	load_position(block->get_position());
 }
 
-/**
- * @brief Parse a comment block ending with * / (without the space, can't write it here in C++ :-) )
- */
-void wpl_block_parser::parse_comment() {
-	wpl_matcher_position start = get_position();
-
-	while (get_letter ('*', NON_ASTERISK)) {
-		if (ignore_letter ('/')) {
-			return;
-		}
-	}
-
-	load_position(start);
-	revert_string(2);
-
-	THROW_ELEMENT_EXCEPTION("Could not find comment end for this comment");
-}
-

--- a/src/libwpl/block_parser.h
+++ b/src/libwpl/block_parser.h
@@ -60,6 +60,5 @@ class wpl_block_parser : public wpl_parse_and_run, public wpl_namespace {
 
 //	const wpl_parse_and_run *find_parse_and_run(const char *name);
 	void parse_parse_and_run(wpl_parse_and_run *block);
-	void parse_comment();
 	
 };

--- a/src/libwpl/expression.cpp
+++ b/src/libwpl/expression.cpp
@@ -62,7 +62,7 @@ int wpl_expression::run (
 		wpl_value *final_result
 		)
 {
-//	dump();
+	//dump();
 
 	wpl_expression_state *exp_state = (wpl_expression_state*) state;
 	exp_state->revert();

--- a/src/libwpl/expression_state.h
+++ b/src/libwpl/expression_state.h
@@ -142,6 +142,22 @@ class wpl_expression_state : public wpl_state {
 		run_stack.unpop();
 	}
 
+	void push_extra(shunting_yard_carrier ca) {
+		run_stack.push_front(ca);
+		run_stack.save_pos();
+
+		child_states.clear();
+		child_states.resize(run_stack.size());
+	}
+
+	void push_extra(const wpl_operator_struct *op) {
+		push_extra(shunting_yard_carrier(op));
+	}
+
+	void push_extra(wpl_value *value) {
+		push_extra(shunting_yard_carrier(value));
+	}
+
 	wpl_exp_deque<shunting_yard_carrier> &get_stack() {
 		return run_stack;
 	}

--- a/src/libwpl/io.h
+++ b/src/libwpl/io.h
@@ -41,6 +41,9 @@ class wpl_io {
 	char buf[256];
 
 	public:
+	wpl_io (const wpl_io &copy) = delete;
+	wpl_io () {}
+
 	wpl_io &operator<< (const char *rhs) {
 		write(rhs, strlen(rhs));
 		return *this;
@@ -126,6 +129,7 @@ class wpl_io_standard : public wpl_io {
 class wpl_io_string_wrapper : public wpl_io {
 	private:
 	string &target;
+
 	public:
 	wpl_io_string_wrapper (string &target) :
 		target(target)
@@ -144,6 +148,12 @@ class wpl_io_string_wrapper : public wpl_io {
 	}
 	void debug (const char *str) override {
 		throw runtime_error("wpl_io_string_wrapper::debug(): Not supported");
+	}
+	const char *c_str() const {
+		return target.c_str();
+	}
+	int size() const {
+		return target.size();
 	}
 };
 

--- a/src/libwpl/matcher.h
+++ b/src/libwpl/matcher.h
@@ -291,6 +291,15 @@ class wpl_matcher {
 		return 0;
 	}
 
+	inline int ignore_many_letters (const char letter) {
+		int total = 0;
+		while (text_rpos[0] == letter) {
+			text_rpos++;
+			total++;
+		}
+		return total;
+	}
+
 	inline void ignore_string (const int len) {
 		text_rpos += len;
 		if (text_rpos > text_max) {

--- a/src/libwpl/parse_and_run.cpp
+++ b/src/libwpl/parse_and_run.cpp
@@ -26,28 +26,3 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-#include "parse_and_run.h"
-
-#include "type_parse_signals.h"
-
-/**
- * @brief Parse a parseable with unknown, but funky syntax. The parseable can add something to our namespace if it wants to.
- */
-void wpl_parse_and_run::parse_parseable_identifier(wpl_namespace *ns, wpl_parseable_identifier *parseable) {
-	parseable->load_position(get_position());
-
-	try {
-		try {
-			parseable->parse_value(ns);
-		}
-		catch (wpl_type_begin_variable_declaration &e) {
-			e.create_variable(ns);
-			load_position(e.get_position_at_name());
-		}
-	}
-	catch (wpl_type_begin_function_declaration &e) {
-		e.load_position(parseable->get_position());
-		e.parse_value(ns);
-		load_position(e.get_position());
-	}
-}

--- a/src/libwpl/parse_and_run.h
+++ b/src/libwpl/parse_and_run.h
@@ -56,5 +56,4 @@ class wpl_parse_and_run : public wpl_parseable, public wpl_runable {
 	}
 	virtual void set_expect_blockstart() {}
 	virtual wpl_parse_and_run *new_instance() const = 0;
-	void parse_parseable_identifier(wpl_namespace *ns, wpl_parseable_identifier *parseable);
 };

--- a/src/libwpl/parser.h
+++ b/src/libwpl/parser.h
@@ -2,7 +2,7 @@
 
 -------------------------------------------------------------
 
-Copyright (c) MMXIII Atle Solbakken
+Copyright (c) MMXIV Atle Solbakken
 atle@goliathdns.no
 
 -------------------------------------------------------------
@@ -70,5 +70,11 @@ class wpl_parser : public wpl_matcher {
 	wpl_parser (wpl_io &io, int num_parents);
 	~wpl_parser ();
 	void parse_file(wpl_namespace *parent_namespace, const char *filename);
+	static wpl_matcher_position parse_parseable_identifier(
+		wpl_namespace *ns,
+		wpl_matcher *matcher,
+		wpl_parseable_identifier *parseable
+	);
+	static void parse_comment(wpl_matcher *matcher);
 };
 

--- a/src/libwpl/pragma.h
+++ b/src/libwpl/pragma.h
@@ -30,6 +30,8 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "template.h"
 #include "scene.h"
+#include "array.h"
+#include "types.h"
 #include "pragma_names.h"
 #include "namespace_session.h"
 #include "pragma_state.h"
@@ -41,8 +43,11 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 class wpl_value;
 class wpl_namespace;
 
+extern const wpl_type_array *wpl_type_global_array;
+extern const wpl_type_string *wpl_type_global_string;
+
 class wpl_pragma : public wpl_parse_and_run {
-	private:
+	protected:
 	const char terminator;
 
 	public:
@@ -114,6 +119,7 @@ class wpl_pragma_template_var : public wpl_pragma {
 	protected:
 	wpl_template *my_template;
 	unique_ptr<wpl_expression> value_expression;
+	shared_ptr<const wpl_type_complete> array_type;
 
 public:
 	wpl_pragma_template_var(const char terminator) :
@@ -135,27 +141,21 @@ public:
 
 class wpl_pragma_template : public wpl_pragma {
 	protected:
-	wpl_template *my_template;
 	unique_ptr<wpl_expression> exp;
+	string template_name;
 
 	wpl_template *get_template(wpl_pragma_state *pragma_state);
 
 	public:
 	wpl_pragma_template(const char *name, const char terminator) :
 		wpl_pragma (name, terminator)
-	{
-		my_template = NULL;
-	}
+	{}
 	wpl_pragma_template(const char terminator) :
 		wpl_pragma (wpl_pragma_name_template, terminator)
-	{
-		my_template = NULL;
-	}
+	{}
 	wpl_pragma_template (const wpl_pragma_template &copy) :
 		wpl_pragma (copy)
-	{
-		my_template = NULL;
-	}
+	{}
 	virtual wpl_pragma_template *new_instance() const {
 		return new wpl_pragma_template(*this);
 	}

--- a/src/libwpl/state.h
+++ b/src/libwpl/state.h
@@ -91,6 +91,9 @@ class wpl_state {
 		return parent->find_parent<T>();
 	}
 
+	void unset_json_output() {
+		flags &= (~DO_JSON_OUTPUT);
+	}
 
 	void set_json_output() {
 		flags |= DO_JSON_OUTPUT;

--- a/src/libwpl/struct.cpp
+++ b/src/libwpl/struct.cpp
@@ -34,6 +34,7 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 #include "value_struct.h"
 #include "debug.h"
 #include "user_function.h"
+#include "parser.h"
 #include "type_parse_signals.h"
 
 #include "global.h"
@@ -101,26 +102,13 @@ void wpl_struct::parse_value(wpl_namespace *ns) {
 	}
 
 	do {
-		wpl_parseable *parseable;
-
 		ignore_whitespace();
 
 		wpl_matcher_position def_begin = get_position();
 
 		// Check for comment
 		if (ignore_string ("/*")) {
-			while (get_letter ('*', NON_ASTERISK)) {
-				if (ignore_letter ('/')) {
-					goto comment_ok;
-				}
-			}
-
-			load_position(def_begin);
-			revert_string(2);
-
-			THROW_ELEMENT_EXCEPTION("Could not find comment end for this comment");
-
-			comment_ok:
+			wpl_parser::parse_comment(this);
 			ignore_whitespace();
 		}
 
@@ -187,6 +175,7 @@ void wpl_struct::parse_value(wpl_namespace *ns) {
 
 		// Check for other parseables
 		{
+			wpl_parseable_identifier *parseable;
 			if (!(parseable = global_block->find_parseable(buf))) {
 				if (!(parseable = find_parseable(buf))) {
 					load_position(def_begin);
@@ -196,7 +185,9 @@ void wpl_struct::parse_value(wpl_namespace *ns) {
 			}
 
 			parseable->load_position(get_position());
+			load_position(wpl_parser::parse_parseable_identifier(this, this, parseable));
 
+			/*
 			try {
 				try {
 					parseable->parse_value(this);
@@ -210,7 +201,7 @@ void wpl_struct::parse_value(wpl_namespace *ns) {
 				e.parse_value(this);
 				load_position(e.get_position());
 			}
-	
+	*/
 			goto definition_out;
 		}
 

--- a/src/libwpl/text.h
+++ b/src/libwpl/text.h
@@ -40,6 +40,7 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 #include <memory>
 
 class wpl_value;
+class wpl_value_array;
 class wpl_namespace_session;
 
 class wpl_text_chunk_end_reached {};
@@ -96,31 +97,16 @@ namespace wpl_text_chunks {
 			return true;
 		}
 	};
-/*
-	class html_template : public base {
-		private:
-		wpl_template *my_template;
 
-		public:
-		html_template (wpl_template *my_template) :
-			my_template(my_template)
-		{}
-		virtual ~html_template() {}
-
-		int run (wpl_text_state *state, int index, wpl_value *final_result, wpl_io &io) override;
-		int output_json (
-			wpl_text_state *state,
-			wpl_value *final_result
-		);
-	};
-*/
 	class runable : public base {
 		private:
 		unique_ptr<wpl_runable> block;
+		int tabs;
 
 		public:
-		runable (wpl_runable *block) :
-			block(block)
+		runable (wpl_runable *block, int tabs) :
+			block(block),
+			tabs(tabs)
 		{}
 		virtual ~runable() {}
 
@@ -212,12 +198,12 @@ class wpl_text : public wpl_parse_and_run {
 		wpl_parse_and_run("TEXT"),
 		global_types(global_types),
 		par_level(1)
-	{};
+	{}
 	wpl_text (const char *name, const wpl_namespace *global_types) :
 		wpl_parse_and_run(name),
 		global_types(global_types),
 		par_level(1)
-	{};
+	{}
 	wpl_text(const wpl_text &copy) :
 		wpl_parse_and_run(copy),
 		global_types(copy.global_types),
@@ -248,7 +234,7 @@ class wpl_text : public wpl_parse_and_run {
 	virtual void parse_value(wpl_namespace *parent_namespace) override;
 	virtual int run(wpl_state *state, wpl_value *final_result) override;
 
-	int output_json(wpl_state *state, const set<wpl_value*> &vars, wpl_value *final_result);
+	int output_json(wpl_state *state, const wpl_value_array *vars, wpl_value *final_result);
 	int output_as_json_var(wpl_state *state, wpl_value *final_result);
 };
 

--- a/src/libwpl/text_state.cpp
+++ b/src/libwpl/text_state.cpp
@@ -27,23 +27,47 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "text_state.h"
+#include "value_array.h"
 #include "runable.h"
 #include "text.h"
 #include "operator_types.h"
 
-int wpl_text_state::run_runable(wpl_runable *runable, int index, wpl_value *final_result) {
-	if (runable_states[index].get() == nullptr) {
-		runable_states[index].reset(runable->new_state(this, get_nss(), &get_io()));
+bool wpl_text_state::has_var(const string name) {
+	for (int i = 0; i < vars->size(); i++) {
+		const wpl_value *value = vars->get_readonly(i);
+		if (value->toString() == name) {
+			return true;
+		}
 	}
+	return false;
+}
+
+wpl_state *wpl_text_state::get_child_state(wpl_runable *runable, int index) {
+	wpl_state *runable_state;
+	try {
+		if (runable_state = child_states.at(index).get()) {
+			return runable_state;
+		}
+	}
+	catch (const std::out_of_range &e) {
+		throw runtime_error("BUG: Size of text children state array not correctly set");
+	}
+
+	child_states[index].reset(runable->new_state(this, get_nss(), &get_io()));
+
+	return child_states[index].get();
+}
+
+int wpl_text_state::run_runable(wpl_runable *runable, int index, wpl_value *final_result) {
 	final_result->set_do_finalize();
-	return runable->run(runable_states[index].get(), final_result);
+
+	wpl_state *runable_state = get_child_state(runable, index);
+	return runable->run(runable_state, final_result);
 }
 
 int wpl_text_state::run_text(wpl_text *text, int index, wpl_value *final_result, wpl_io &io) {
-	if (text_states[index].get() == nullptr) {
-		text_states[index].reset(text->new_state(this, get_nss(), &get_io()));
-	}
-	return text->run(text_states[index].get(), final_result);
+	wpl_state *text_state = get_child_state(text, index);
+	return text->run(text_state, final_result);
 }
 
 int wpl_text_state::run_text_output_json (
@@ -51,8 +75,5 @@ int wpl_text_state::run_text_output_json (
 		int index,
 		wpl_value *final_result
 ) {
-	if (text_states[index].get() == nullptr) {
-		text_states[index].reset(text->new_state(this, get_nss(), &get_io()));
-	}
-	return text->output_json(text_states[index].get(), get_vars(), final_result);
+	return text->output_json(get_child_state(text, index), get_vars(), final_result);
 }

--- a/src/libwpl/value.h
+++ b/src/libwpl/value.h
@@ -251,7 +251,7 @@ class wpl_value : public wpl_suicidal {
 		cerr << "In value toBool() of type '" << get_type_name() << "':\n";
 		throw runtime_error ("Cannot get bool value of this type");
 	}
-	virtual string toString() {
+	virtual string toString() const {
 		cerr << "In value toString() of type '" << get_type_name() << "':\n";
 		throw runtime_error ("Cannot get string value of this type");
 	}

--- a/src/libwpl/value_array.h
+++ b/src/libwpl/value_array.h
@@ -99,7 +99,7 @@ class wpl_value_array : public wpl_value_template, public wpl_array {
 
 
 #ifdef WPL_DEBUG_EXPRESSIONS
-	string toString() {
+	string toString() const {
 		return string("DBG{array ") + template_type->get_name() + "}";
 	}
 #endif

--- a/src/libwpl/value_auto.h
+++ b/src/libwpl/value_auto.h
@@ -211,7 +211,7 @@ class wpl_value_auto : public wpl_value {
 	bool toBool() override {
 		return my_value.get() ? my_value->toBool() : false;
 	}
-	string toString() override {
+	string toString() const override {
 		return my_value.get() ? my_value->toString() : "";
 	}
 	string toStringDBG() override {

--- a/src/libwpl/value_bool.h
+++ b/src/libwpl/value_bool.h
@@ -52,7 +52,7 @@ class wpl_value_bool : public wpl_value_number<bool> {
 	double toDouble() override {
 		return (value ? 1 : 0);
 	}
-	string toString() override {
+	string toString() const override {
 		return (value ? string("true") : string ("false"));
 	}
 };

--- a/src/libwpl/value_line.cpp
+++ b/src/libwpl/value_line.cpp
@@ -78,7 +78,7 @@ notfile:
 	chunk->set_data(value->toString());
 }
 
-string wpl_value_line::toString() {
+string wpl_value_line::toString() const {
 	if (!chunk) {
 		throw runtime_error("Cannot get string value of LINE as it does not yet point to any data. Try line++ first?");
 	}

--- a/src/libwpl/value_line.h
+++ b/src/libwpl/value_line.h
@@ -57,7 +57,7 @@ class wpl_value_line : public wpl_value {
 		set_weak(value);
 		return true;
 	}
-	string toString() override;
+	string toString() const override;
 	bool toBool() override {
 		return (chunk) && chunk->get_size();
 	}

--- a/src/libwpl/value_number.h
+++ b/src/libwpl/value_number.h
@@ -143,7 +143,7 @@ template<typename A> class wpl_value_number : public wpl_value_holder<A> {
 	double toDouble() override {
 		return (double) wpl_value_holder<A>::value;
 	}
-	string toString() override {
+	string toString() const override {
 		return to_string(wpl_value_holder<A>::value);
 	}
 };

--- a/src/libwpl/value_stdin.h
+++ b/src/libwpl/value_stdin.h
@@ -55,7 +55,7 @@ class wpl_value_stdin : public wpl_value {
 			wpl_value *rhs
 	);
 
-	string toString() override {
+	string toString() const override {
 		string res;
 		getline (cin, res);
 		return res;

--- a/src/libwpl/value_string.h
+++ b/src/libwpl/value_string.h
@@ -105,7 +105,7 @@ class wpl_value_string : public wpl_value_strings<string>, public wpl_parasite_h
 	double toDouble() {
 		return strtod (value.c_str(), NULL);
 	}
-	string toString() {
+	string toString() const override {
 		return value;
 	}
 	string &rawToString() {

--- a/src/libwpl/value_struct.h
+++ b/src/libwpl/value_struct.h
@@ -117,7 +117,7 @@ class wpl_value_struct : public wpl_value, public wpl_namespace_session {
 	void notify_destructor(wpl_state *state, wpl_namespace_session *nss, wpl_io &io) override;
 
 #ifdef WPL_DEBUG_EXPRESSIONS
-	string toString() {
+	string toString() const {
 		return string("DBG{struct ") + mother_struct->get_name() + "}";
 	}
 #endif

--- a/src/libwpl/value_time.cpp
+++ b/src/libwpl/value_time.cpp
@@ -63,7 +63,7 @@ void wpl_value_time::set_weak (wpl_value *value) {
 	}
 }
 
-string wpl_value_time::toString() {
+string wpl_value_time::toString() const {
 	string tmp;
 	format_time(NULL, tmp);
 	return tmp;

--- a/src/libwpl/value_time.h
+++ b/src/libwpl/value_time.h
@@ -50,7 +50,7 @@ class wpl_value_time : public wpl_value, public wpl_time, public wpl_parasite_ho
 	wpl_value_time *clone_empty() const { return new wpl_value_time(0); };
 
 	void set_weak(wpl_value *value) override;
-	string toString() override;
+	string toString() const override;
 	char* get_mysql_time_ptr();
 
 	void output_json(wpl_io &io) override;

--- a/src/libwpl/value_unresolved.h
+++ b/src/libwpl/value_unresolved.h
@@ -73,7 +73,7 @@ class wpl_value_unresolved_identifier : public wpl_value_strings<string> {
 		throw runtime_error("Cannot output unresolved identifiers");
 	}
 
-	string toString() {
+	string toString() const {
 		return value;
 	}
 

--- a/src/libwpl/value_void.h
+++ b/src/libwpl/value_void.h
@@ -39,5 +39,21 @@ class wpl_value_void : public wpl_value_holder<wpl_void> {
 	wpl_value_void *clone() const {
 		return new wpl_value_void(*this);
 	}
+
+	/* Allow output, but do nothing */
+	void output(wpl_io &io) override {}
+
+	/* Allow finalize, but don't set */
+	int finalize_expression(wpl_expression_state *exp_state, wpl_value *final_result) override {
+		return WPL_OP_NO_RETURN;
+	}
+
+	/* Return 0 for toInt() */
+	int toInt() override {
+		return 0;
+	}
+	string toString() const override {
+		return string();
+	}
 };
 

--- a/src/libwpl/value_vstring.h
+++ b/src/libwpl/value_vstring.h
@@ -60,6 +60,9 @@ class wpl_value_vstring : public wpl_value {
 		char* operator* () {
 			return data;
 		}
+		const char* operator* () const {
+			return data;
+		}
 		char &operator[] (const int i) {
 			return data[i];
 		}
@@ -120,8 +123,9 @@ class wpl_value_vstring : public wpl_value {
 	double toDouble() {
 		return strtod (*my_vstring, NULL);
 	}
-	string toString() {
-		return string(*my_vstring);
+	string toString() const {
+		string ret(*my_vstring);
+		return ret;
 	}
 	char *toVoid() {
 		return *my_vstring;

--- a/src/libwpl/value_wrapper.h
+++ b/src/libwpl/value_wrapper.h
@@ -99,7 +99,7 @@ class wpl_value_wrapper : public wpl_value {
 	int toInt() { return value->toInt(); };
 	float toFloat() { return value->toFloat(); };
 	double toDouble() { return value->toDouble(); };
-	string toString() { return value->toString(); };
+	string toString() const { return value->toString(); };
     char* toVoid(){ return value->toVoid(); }
 };
 

--- a/src/libwpl/wpl_time.h
+++ b/src/libwpl/wpl_time.h
@@ -63,11 +63,11 @@ class wpl_time {
 		timestamp = src;
 	}
 
-	time_t get_time() {
+	time_t get_time() const {
 		return timestamp;
 	}
 
-	time_t get_time(struct tm *dst) {
+	time_t get_time(struct tm *dst) const {
 		localtime_r(&timestamp, dst);
         return timestamp;
 	}
@@ -86,7 +86,7 @@ class wpl_time {
 		return format;
 	}
 
-	void format_time(const char *format, string &dst) {
+	void format_time(const char *format, string &dst) const {
 		if (format == NULL) {
 			format = this->format;
 		}


### PR DESCRIPTION
- Change in the JSON implementation where the pointer of a variable was searched for, the ID tag is used to match instead
- Allow definition of structs in global namespace
- Allow comments in global namespace
- HTML_TEMPLATE pragma does not resolve names at parse time
- HTML_TEMPLATE_VAR takes a comma-separated list of IDs to print out from the template
