### PR TITLE
Multiple fixes for JSON and eeb server environment support

### DIFF
--- a/src/apache2/pstar_io.cpp
+++ b/src/apache2/pstar_io.cpp
@@ -41,6 +41,16 @@ pstar_io::~pstar_io() {
 	apr_status_t rv;
 	apr_bucket *b;
 
+	static const char msg[] = "<h1>P* Error</h1><p>An error occured. More information can be found in the web server log files.</p>";
+
+	if (http_error_pending) {
+		apr_table_set (r->headers_out, "Content-Type", "text/html");
+
+//		apr_brigade_cleanup(bb);
+		b = apr_bucket_immortal_create(msg, sizeof(msg), ba);
+		APR_BRIGADE_INSERT_TAIL(bb, b);
+	}
+
 	b = apr_bucket_eos_create(ba);
 	APR_BRIGADE_INSERT_TAIL(bb, b);
 
@@ -140,6 +150,11 @@ const char *pstar_io::get_env(const char *name) {
 }
 
 void pstar_io::debug(const char *str) {
+	ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "%s", str);
+}
+
+void pstar_io::error(const char *str) {
+	http_error_pending = true;
 	ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "%s", str);
 }
 

--- a/src/apache2/pstar_io.h
+++ b/src/apache2/pstar_io.h
@@ -28,8 +28,10 @@ class pstar_io : public wpl_io {
 	private:
 	string input;
 	int rpos;
-	bool headers_sent;
 	int waiting_buckets;
+
+	bool headers_sent = false;
+	bool http_error_pending = false;
 
 	map<string,string> http_headers;
 
@@ -47,6 +49,7 @@ class pstar_io : public wpl_io {
 	const char *get_env(const char *name) override;
 	void http_header (const char *field, const char *str) override;
 	void debug (const char *str) override;
+	void error (const char *str) override;
 
 	void append_input (const char *str, int len);
 	void output_headers ();

--- a/src/libwpl/exception.cpp
+++ b/src/libwpl/exception.cpp
@@ -29,15 +29,17 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 #include "exception.h"
 
 void wpl_element_exception::output(wpl_io &io) const {
-	char tmp[40+1];
-
 	wpl_matcher line_counter(pos);
 
 	int line = line_counter.get_linepos();
 	int col = line_counter.get_colpos();
 
-	line_counter.get_string_unsafe (tmp, 40);
-	tmp[40] = '\0';
+	line_counter.go_to_linestart();
+	const char *start = line_counter.get_string_pointer();
+	line_counter.ignore_string_match(wpl_matcher::NEWLINE, wpl_matcher::ALL);
+	const char *end = line_counter.get_string_pointer();
+
+	string tmp(start, end-start);
 
 	ostringstream final_msg;
 
@@ -46,5 +48,5 @@ void wpl_element_exception::output(wpl_io &io) const {
 		" column " << col <<
 		" near '" << tmp << "': " << text << endl;
 
-	io.debug(final_msg.str().c_str());
+	io.error(final_msg.str().c_str());
 }

--- a/src/libwpl/io.cpp
+++ b/src/libwpl/io.cpp
@@ -31,7 +31,7 @@ along with P*.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdlib.h>
 
 void wpl_io_standard::http_header(const char *field, const char *str) {
-        cout << field << ": " << str << ";\r\n\r\n";
+        cout << field << ": " << str << "\r\n\r\n";
 }
 
 const char *wpl_io_standard::get_env(const char *name) {

--- a/src/libwpl/io.h
+++ b/src/libwpl/io.h
@@ -101,6 +101,7 @@ class wpl_io {
 	virtual const char *get_env (const char *name) = 0;
 	virtual void http_header(const char *field, const char *str) = 0;
 	virtual void debug (const char *str) = 0;
+	virtual void error (const char *str) = 0;
 
 	virtual void write_immortal (const char *str, int len) {
 		write(str, len);
@@ -122,6 +123,10 @@ class wpl_io_standard : public wpl_io {
 	void http_header(const char *field, const char *str) override;
 
 	void debug (const char *str) override {
+		std::cerr << str;
+	}
+
+	void error (const char *str) override {
 		std::cerr << str;
 	}
 };
@@ -148,6 +153,9 @@ class wpl_io_string_wrapper : public wpl_io {
 	}
 	void debug (const char *str) override {
 		throw runtime_error("wpl_io_string_wrapper::debug(): Not supported");
+	}
+	void error (const char *str) override {
+		throw runtime_error("wpl_io_string_wrapper::error(): Not supported");
 	}
 	const char *c_str() const {
 		return target.c_str();
@@ -182,6 +190,10 @@ class wpl_io_buffer : public wpl_io {
 		buffer += string(str);
 	}
 
+	void error (const char *str) override {
+		debug(str);
+	}
+
 	void output (wpl_io &target) {
 		target.write(buffer);
 	}
@@ -202,4 +214,5 @@ class wpl_io_void : public wpl_io {
 	const char *get_env (const char *name) { throw runtime_error("wpl_io_dummy::get_env(): Not supported"); }
 	void http_header(const char *field, const char *str) {}
 	void debug (const char *str) {}
+	void error (const char *str) {}
 };

--- a/src/libwpl/matcher.cpp
+++ b/src/libwpl/matcher.cpp
@@ -393,3 +393,14 @@ int wpl_matcher::ignore_string_match (const uint32_t match, const uint32_t ignor
 	return get_string (&dummy, match, ignore);
 }
 
+void wpl_matcher::go_to_linestart() {
+	while (text_rpos >= text) {
+		if (M_NEWLINE(*text_rpos)) {
+			text_rpos++;
+			return;
+		}
+		text_rpos--;
+	}
+
+	text_rpos = text;
+}

--- a/src/libwpl/matcher.h
+++ b/src/libwpl/matcher.h
@@ -352,6 +352,8 @@ class wpl_matcher {
 
 	int ignore_string_match (const uint32_t match, const uint32_t ignore);
 
+	void go_to_linestart();
+
 	public:
 	void load_position (const wpl_matcher_position &pos) {
 		text = pos.text;

--- a/src/libwpl/namespace.cpp
+++ b/src/libwpl/namespace.cpp
@@ -187,7 +187,7 @@ wpl_identifier *wpl_namespace::find_identifier_no_parent (const char *name) {
  *
  * @return Return the scene on success or NULL on failure.
  */
-wpl_scene *wpl_namespace::find_scene (const char *name) {
+wpl_scene *wpl_namespace::find_scene (const char *name) const {
 	for (wpl_scene *scene : scenes) {
 		if (strcmp (name, scene->wpl_identifier::get_name()) == 0) {
 			return scene;

--- a/src/libwpl/namespace.h
+++ b/src/libwpl/namespace.h
@@ -192,7 +192,7 @@ class wpl_namespace {
 
 	void generate_typename_list (ostringstream &target);
 
-	wpl_scene *find_scene (const char *name);
+	wpl_scene *find_scene (const char *name) const;
 	wpl_template *find_template (const char *name) const;
 
 	wpl_variable *find_variable (const char *name) const;

--- a/src/libwpl/namespace_session.cpp
+++ b/src/libwpl/namespace_session.cpp
@@ -365,6 +365,13 @@ wpl_function *wpl_namespace_session::find_function_no_parent(const char *name, i
 	return NULL;
 }
 
+wpl_scene *wpl_namespace_session::find_scene(const char *name) {
+	if (!template_namespace) {
+		return NULL;
+	}
+	return template_namespace->find_scene(name);
+}
+
 wpl_template *wpl_namespace_session::find_template(const char *name) {
 	if (!template_namespace) {
 		return NULL;

--- a/src/libwpl/namespace_session.h
+++ b/src/libwpl/namespace_session.h
@@ -44,6 +44,7 @@ enum {
 };
 
 class wpl_state;
+class wpl_scene;
 class wpl_template;
 class wpl_expression_state;
 class wpl_value_unresolved_identifier;
@@ -108,6 +109,7 @@ class wpl_namespace_session {
 	virtual wpl_variable *find_variable(const char *name, int ctx);
 	wpl_function *find_function_no_parent(const char *name, int ctx);
 	wpl_template *find_template (const char *name);
+	wpl_scene *find_scene (const char *name);
 	const wpl_type_complete *find_complete_type (const char *name);
 
 	virtual int do_operator_on_unresolved (

--- a/src/libwpl/pragma_names.h
+++ b/src/libwpl/pragma_names.h
@@ -32,6 +32,7 @@ static const char *wpl_pragma_name_scene =		"#SCENE";
 static const char *wpl_pragma_name_template_as_var =	"#HTML_TEMPLATE_AS_VAR";
 static const char *wpl_pragma_name_template =		"#HTML_TEMPLATE";
 static const char *wpl_pragma_name_template_var =	"#HTML_TEMPLATE_VAR";
+static const char *wpl_pragma_name_http_error =		"#HTTP_ERROR";
 static const char *wpl_pragma_name_json_begin = 	"#JSON_BEGIN";
 static const char *wpl_pragma_name_json_end =		"#JSON_END";
 static const char *wpl_pragma_name_content_type =	"#CONTENT_TYPE";

--- a/src/libwpl/pragma_state.h
+++ b/src/libwpl/pragma_state.h
@@ -52,6 +52,9 @@ class wpl_pragma_state : public wpl_state {
 	wpl_template *find_template(const char *name) {
 		return get_nss()->find_template(name);
 	}
+	wpl_scene *find_scene(const char *name) {
+		return get_nss()->find_scene(name);
+	}
 	void set_children_count(int count) {
 		child_state.resize(count);
 	}

--- a/src/libwpl/value_post.cpp
+++ b/src/libwpl/value_post.cpp
@@ -78,9 +78,9 @@ void wpl_value_post::parse_entity (MimeEntity *me) {
 		out = me->body();
 
 		copy_done:
-		wpl_value_array *storage = (wpl_value_array*) hash.get(name);
+		wpl_value_array *storage = (wpl_value_array*) hash->get(name);
 		if (!storage) {
-			storage = (wpl_value_array*) hash.define(name);
+			storage = (wpl_value_array*) hash->define(name);
 		}
 		storage->push(new wpl_value_string(out));
 	}
@@ -127,10 +127,15 @@ void wpl_value_post::parse(wpl_io &io) {
 	io.read(buf, length);
 	buf[length] = '\0';
 
-	if (strcmp(content_type, "application/x-www-form-urlencoded") == 0) {
-		value_get.parse(buf);
+	const char srch_a[] = "application/x-www-form-urlencoded";
+	char srch_b[sizeof(srch_a)];
+	memcpy(srch_b, content_type, sizeof(srch_b));
+	srch_b[sizeof(srch_b)-1] = '\0';
 
-		use_get = true;
+	if (strcmp(srch_a, srch_b) == 0) {
+		value_get->parse(buf);
+
+		*use_get = true;
 		return;
 	}
 
@@ -155,26 +160,26 @@ int wpl_value_post::do_operator (
 		wpl_value *lhs,
 		wpl_value *rhs
 ) {
-	if (!did_parse) {
+	if (!*did_parse) {
 		parse(exp_state->get_io());
-		did_parse = true;
+		*did_parse = true;
 	}
 
-	if (use_get) {
-		return value_get.do_operator(
+	if (*use_get) {
+		return value_get->do_operator(
 			exp_state,
 			final_result,
 			op,
-			(lhs == this ? &value_get : lhs),
-			(rhs == this ? &value_get : rhs)
+			(lhs == this ? value_get.get() : lhs),
+			(rhs == this ? value_get.get() : rhs)
 		);
 	}
 
-	return hash.do_operator (
+	return hash->do_operator (
 		exp_state,
 		final_result,
 		op,
-		(lhs == this ? &hash : lhs),
-		(rhs == this ? &hash : rhs)
+		(lhs == this ? hash.get() : lhs),
+		(rhs == this ? hash.get() : rhs)
 	);
 }

--- a/src/libwpl/value_post.h
+++ b/src/libwpl/value_post.h
@@ -46,13 +46,12 @@ class wpl_operator_struct;
 class wpl_value_post : public wpl_value {
 	private:
 
-	bool did_parse;
 	void parse(wpl_io &io);
 
-	wpl_value_hash hash;
-	wpl_value_get value_get;
-
-	bool use_get;
+	shared_ptr<bool> did_parse;
+	shared_ptr<wpl_value_hash> hash;
+	shared_ptr<wpl_value_get> value_get;
+	shared_ptr<bool> use_get;
 
 	// Initialized in .cpp
 	static wpl_type_array_instance type_complete_array;
@@ -63,10 +62,10 @@ class wpl_value_post : public wpl_value {
 	public:
 	PRIMITIVE_TYPEINFO(get)
 	wpl_value_post(int dummy) :
-		hash(&type_complete_hash, &type_complete_array),
-		did_parse(false),
-		use_get(false),
-		value_get(0)
+		hash(new wpl_value_hash (&type_complete_hash, &type_complete_array)),
+		value_get(new wpl_value_get (0)),
+		did_parse(new bool(false)),
+		use_get(new bool (false))
 	{}
 	wpl_value_post *clone() const { return new wpl_value_post(0); };
 	wpl_value_post *clone_empty() const { return new wpl_value_post(0); };
@@ -78,4 +77,15 @@ class wpl_value_post : public wpl_value {
 			wpl_value *lhs,
 			wpl_value *rhs
 	);
+
+	void set_weak (wpl_value *value) override {
+		wpl_value_post *post = dynamic_cast<wpl_value_post*>(value);
+		if (!post) {
+			ostringstream msg;
+			msg << "Cannot set POST value to value of type " << value->get_type_name() << endl;
+			throw runtime_error(msg.str());
+		}
+
+		*this = *post;
+	}
 };


### PR DESCRIPTION
- Fixed bug in Apache module where errors were handled improperly and blank data was sent to user
- Added error message pragma #HTTP_ERROR which ends the program, logs it, and prints a default error message to the user
- Remove malplaced semicolon which the  CONTENT_TYPE-pragma put in the HTTP header
- Fix error message output in wpl_element_exception, print the whole line the error is on
- Support run time resolving of SCENE name in SCENE pragma and expression support with @-prefix
- Enable set_weak in POST value so that it can be passed as function argument, using shared_ptr on all values.
- Fix recognition of application/x-www-form-urlencoded
